### PR TITLE
Feat: RedisCache를 통한 캐싱 적용 (#44) [잔여 부분]

### DIFF
--- a/src/main/java/com/diareat/diareat/food/controller/FoodController.java
+++ b/src/main/java/com/diareat/diareat/food/controller/FoodController.java
@@ -49,8 +49,8 @@ public class FoodController {
     //음식 삭제
     @Operation(summary = "[음식] 음식 정보 삭제",description = "음식에 대한 정보를 삭제합니다.")
     @DeleteMapping("/{foodId}/delete")
-    public ApiResponse<Void> deleteFood(@PathVariable Long foodId){
-        foodService.deleteFood(foodId);
+    public ApiResponse<Void> deleteFood(@PathVariable Long foodId, @RequestHeader Long userId){
+        foodService.deleteFood(foodId, userId);
         return ApiResponse.success(null, ResponseCode.FOOD_DELETE_SUCCESS.getMessage());
     }
 
@@ -79,8 +79,8 @@ public class FoodController {
     //즐겨찾기 음식 해제
     @Operation(summary = "[즐겨찾기] 즐겨찾기 해제",description = "유저의 즐겨찾기에 등록된 음식을 해제합니다.")
     @DeleteMapping("/favorite/{favoriteFoodId}")
-    public ApiResponse<Void> deleteFavoriteFood(@PathVariable Long favoriteFoodId){
-        foodService.deleteFavoriteFood(favoriteFoodId);
+    public ApiResponse<Void> deleteFavoriteFood(@PathVariable Long favoriteFoodId, @RequestHeader Long userId){
+        foodService.deleteFavoriteFood(favoriteFoodId, userId);
         return ApiResponse.success(null, ResponseCode.FOOD_FAVORITE_DELETE_SUCCESS.getMessage());
     }
 

--- a/src/main/java/com/diareat/diareat/food/dto/CreateFoodDto.java
+++ b/src/main/java/com/diareat/diareat/food/dto/CreateFoodDto.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -13,8 +15,9 @@ public class CreateFoodDto {
     private Long userId;
     private String name;
     private BaseNutrition baseNutrition;
+    private LocalDate date;
 
-    public static CreateFoodDto of(Long userId, String name, BaseNutrition baseNutrition) {
-        return new CreateFoodDto(userId, name, baseNutrition);
+    public static CreateFoodDto of(Long userId, String name, BaseNutrition baseNutrition, LocalDate date) {
+        return new CreateFoodDto(userId, name, baseNutrition, date);
     }
 }

--- a/src/main/java/com/diareat/diareat/food/dto/UpdateFavoriteFoodDto.java
+++ b/src/main/java/com/diareat/diareat/food/dto/UpdateFavoriteFoodDto.java
@@ -11,10 +11,11 @@ import lombok.NoArgsConstructor;
 public class UpdateFavoriteFoodDto {
 
     private Long favoriteFoodId;
+    private Long userId;
     private String name;
     private BaseNutrition baseNutrition;
 
-    public static UpdateFavoriteFoodDto of(Long favoriteFoodId, String name, BaseNutrition baseNutrition) {
-        return new UpdateFavoriteFoodDto(favoriteFoodId, name, baseNutrition);
+    public static UpdateFavoriteFoodDto of(Long favoriteFoodId, Long userId, String name, BaseNutrition baseNutrition) {
+        return new UpdateFavoriteFoodDto(favoriteFoodId, userId, name, baseNutrition);
     }
 }

--- a/src/main/java/com/diareat/diareat/food/dto/UpdateFoodDto.java
+++ b/src/main/java/com/diareat/diareat/food/dto/UpdateFoodDto.java
@@ -11,10 +11,11 @@ import lombok.NoArgsConstructor;
 public class UpdateFoodDto {
 
     private Long foodId;
+    private Long userId;
     private String name;
     private BaseNutrition baseNutrition;
 
-    public static UpdateFoodDto of(Long foodId, String name, BaseNutrition baseNutrition) {
-        return new UpdateFoodDto(foodId, name, baseNutrition);
+    public static UpdateFoodDto of(Long foodId, Long userId, String name, BaseNutrition baseNutrition) {
+        return new UpdateFoodDto(foodId, userId, name, baseNutrition);
     }
 }

--- a/src/main/java/com/diareat/diareat/food/repository/FavoriteFoodRepository.java
+++ b/src/main/java/com/diareat/diareat/food/repository/FavoriteFoodRepository.java
@@ -7,5 +7,6 @@ import java.util.List;
 
 public interface FavoriteFoodRepository extends JpaRepository<FavoriteFood, Long> {
     List<FavoriteFood> findAllByUserId(Long userId);
+    boolean existsByIdAndUserId(Long id, Long userId); // 유저가 즐겨찾기에 추가한 음식인지 확인
     boolean existsByFoodId(Long foodId); // 이미 즐겨찾기에 추가된 음식인지 확인하기 위함
 }

--- a/src/main/java/com/diareat/diareat/food/repository/FoodRepository.java
+++ b/src/main/java/com/diareat/diareat/food/repository/FoodRepository.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface FoodRepository extends JpaRepository<Food, Long> {
+    boolean existsByIdAndUserId(Long id, Long userId); // 유저가 먹은 음식인지 확인
     List<Food> findAllByUserIdAndDate(Long userId, LocalDate date); //유저가 특정 날짜에 먹은 음식 반환
     List<Food> findAllByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate); // 유저가 특정 기간 내에 먹은 음식 반환
 }

--- a/src/main/java/com/diareat/diareat/food/service/FoodService.java
+++ b/src/main/java/com/diareat/diareat/food/service/FoodService.java
@@ -15,8 +15,10 @@ import com.diareat.diareat.util.exception.FavoriteException;
 import com.diareat.diareat.util.exception.FoodException;
 import com.diareat.diareat.util.exception.UserException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.cache.annotation.Cacheable;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -33,6 +35,7 @@ public class FoodService {
     private final UserRepository userRepository;
 
     // 촬영 후, 음식 정보 저장
+    @CacheEvict(value = "ResponseFoodDto", key = "#createFoodDto.getUserId()+#createFoodDto.getDate()", cacheManager = "diareatCacheManager")
     @Transactional
     public Long saveFood(CreateFoodDto createFoodDto) {
         User user = getUserById(createFoodDto.getUserId());
@@ -40,7 +43,8 @@ public class FoodService {
         return foodRepository.save(food).getId();
     }
 
-    // 회원이 특정 날짜에 먹은 음식 반환
+    // 회원이 특정 날짜에 먹은 음식 조회
+    @Cacheable(value = "ResponseFoodDto", key = "#userId+#date", cacheManager = "diareatCacheManager")
     @Transactional(readOnly = true)
     public List<ResponseFoodDto> getFoodListByDate(Long userId, LocalDate date){
         validateUser(userId);
@@ -49,22 +53,25 @@ public class FoodService {
                 .map(food -> ResponseFoodDto.of(food.getId(), food.getUser().getId(), food.getName(), food.getDate(), food.getTime(), food.getBaseNutrition(), food.isFavorite())).collect(Collectors.toList());
     }
 
-
     // 음식 정보 수정
+    @CacheEvict(value = "ResponseFoodDto", key = "#updateFoodDto.getUserId()", cacheManager = "diareatCacheManager")
     @Transactional
     public void updateFood(UpdateFoodDto updateFoodDto) {
         Food food = getFoodById(updateFoodDto.getFoodId());
         food.updateFood(updateFoodDto.getName(), updateFoodDto.getBaseNutrition());
+        foodRepository.save(food);
     }
 
     // 음식 삭제
+    @CacheEvict(value = "ResponseFoodDto", key = "#userId", cacheManager = "diareatCacheManager")
     @Transactional
-    public void deleteFood(Long foodId) {
+    public void deleteFood(Long foodId, Long userId) {
         validateFood(foodId);
         foodRepository.deleteById(foodId);
     }
 
     // 즐겨찾기에 음식 저장
+    @CacheEvict(value = "ResponseFavoriteFoodDto", key = "#createFavoriteFoodDto.getUserId()", cacheManager = "diareatCacheManager")
     @Transactional
     public Long saveFavoriteFood(CreateFavoriteFoodDto createFavoriteFoodDto) {
         User user = getUserById(createFavoriteFoodDto.getUserId());
@@ -75,6 +82,7 @@ public class FoodService {
     }
 
     //즐겨찾기 음식 리스트 반환
+    @Cacheable(value = "ResponseFavoriteFoodDto", key = "#userId", cacheManager = "diareatCacheManager")
     @Transactional(readOnly = true)
     public List<ResponseFavoriteFoodDto> getFavoriteFoodList(Long userId){
         validateUser(userId);
@@ -85,19 +93,23 @@ public class FoodService {
     }
 
     // 즐겨찾기 음식 수정
+    @CacheEvict(value = "ResponseFavoriteFoodDto", key = "updateFavoriteFoodDto.getUserId()", cacheManager = "diareatCacheManager")
     @Transactional
     public void updateFavoriteFood(UpdateFavoriteFoodDto updateFavoriteFoodDto) {
         FavoriteFood food = getFavoriteFoodById(updateFavoriteFoodDto.getFavoriteFoodId());
         food.updateFavoriteFood(updateFavoriteFoodDto.getName(), updateFavoriteFoodDto.getBaseNutrition());
+        favoriteFoodRepository.save(food);
     }
 
     // 즐겨찾기 해제
+    @CacheEvict(value = "ResponseFavoriteFoodDto", key = "#userId", cacheManager = "diareatCacheManager")
     @Transactional
-    public void deleteFavoriteFood(Long favoriteFoodId) {
+    public void deleteFavoriteFood(Long favoriteFoodId, Long userId) {
         validateFavoriteFood(favoriteFoodId);
         favoriteFoodRepository.deleteById(favoriteFoodId);
     }
 
+    @Cacheable(value = "ResponseNutritionSumByDateDto", key = "#userId+#date", cacheManager = "diareatCacheManager")
     @Transactional(readOnly = true)
     // 유저의 특정 날짜에 먹은 음식들의 영양성분별 총합 조회 (섭취영양소/기준영양소 및 비율까지 계산해서 반환, dto 구체적 협의 필요)
     public ResponseNutritionSumByDateDto getNutritionSumByDate(Long userId, LocalDate date) {
@@ -178,6 +190,7 @@ public class FoodService {
     // 유저의 일기 분석 그래프 데이터 및 식습관 totalScore 조회
 
 
+    @Cacheable(value = "ResponseRankUserDto", key = "#userId", cacheManager = "diareatCacheManager")
     @Transactional(readOnly = true)
     // 유저의 식습관 점수를 기반으로 한 주간 랭킹 조회
     public List<ResponseRankUserDto> getUserRankByWeek(Long userId) {

--- a/src/main/java/com/diareat/diareat/food/service/FoodService.java
+++ b/src/main/java/com/diareat/diareat/food/service/FoodService.java
@@ -66,7 +66,7 @@ public class FoodService {
     @CacheEvict(value = "ResponseFoodDto", key = "#userId", cacheManager = "diareatCacheManager")
     @Transactional
     public void deleteFood(Long foodId, Long userId) {
-        validateFood(foodId);
+        validateFood(foodId, userId);
         foodRepository.deleteById(foodId);
     }
 
@@ -105,7 +105,7 @@ public class FoodService {
     @CacheEvict(value = "ResponseFavoriteFoodDto", key = "#userId", cacheManager = "diareatCacheManager")
     @Transactional
     public void deleteFavoriteFood(Long favoriteFoodId, Long userId) {
-        validateFavoriteFood(favoriteFoodId);
+        validateFavoriteFood(favoriteFoodId, userId);
         favoriteFoodRepository.deleteById(favoriteFoodId);
     }
 
@@ -281,14 +281,18 @@ public class FoodService {
             throw new UserException(ResponseCode.USER_NOT_FOUND);
     }
 
-    private void validateFood(Long foodId) {
-        if (!foodRepository.existsById(foodId))
+    private void validateFood(Long foodId, Long userId) {
+        if(!foodRepository.existsById(foodId))
             throw new FoodException(ResponseCode.FOOD_NOT_FOUND);
+        if (!foodRepository.existsByIdAndUserId(foodId, userId)) // 음식의 주인이 유저인지 아닌지 판정
+            throw new FoodException(ResponseCode.NOT_FOOD_OWNER);
     }
 
-    private void validateFavoriteFood(Long favoriteFoodId) {
-        if (!favoriteFoodRepository.existsById(favoriteFoodId))
+    private void validateFavoriteFood(Long favoriteFoodId, Long userId) {
+        if(!favoriteFoodRepository.existsById(favoriteFoodId))
             throw new FavoriteException(ResponseCode.FAVORITE_NOT_FOUND);
+        if(!favoriteFoodRepository.existsByIdAndUserId(favoriteFoodId, userId)) // 즐겨찾는 음식의 주인이 유저인지 아닌지 판정
+            throw new FavoriteException(ResponseCode.NOT_FOOD_OWNER);
     }
 
     // 1주일동안 먹은 음식들의 영양성분 총합을 요일을 Key로 한 Map을 통해 반환

--- a/src/main/java/com/diareat/diareat/util/api/ResponseCode.java
+++ b/src/main/java/com/diareat/diareat/util/api/ResponseCode.java
@@ -14,6 +14,7 @@ public enum ResponseCode {
 
     // 403 Forbidden
     FORBIDDEN(HttpStatus.FORBIDDEN, false, "권한이 없습니다."),
+    NOT_FOOD_OWNER(HttpStatus.FORBIDDEN, false, "음식의 주인 유저가 아닙니다."),
 
     // 404 Not Found
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, "사용자를 찾을 수 없습니다."),

--- a/src/test/java/com/diareat/diareat/service/FoodServiceTest.java
+++ b/src/test/java/com/diareat/diareat/service/FoodServiceTest.java
@@ -89,7 +89,7 @@ class FoodServiceTest {
 
         //when
         BaseNutrition testChangedBaseNutrition = BaseNutrition.createNutrition(2,3,4,5);
-        foodService.updateFood(UpdateFoodDto.of(food.getId(), "testChangedFood", testChangedBaseNutrition));
+        foodService.updateFood(UpdateFoodDto.of(food.getId(), 1L,"testChangedFood", testChangedBaseNutrition));
 
 
         assertEquals("testChangedFood", food.getName());
@@ -110,7 +110,7 @@ class FoodServiceTest {
         given(foodRepository.existsById(food.getId())).willReturn(true);
 
         //when
-        foodService.deleteFood(food.getId());
+        foodService.deleteFood(food.getId(), user.getId());
 
         verify(foodRepository, times(1)).deleteById(food.getId());
     }
@@ -152,7 +152,7 @@ class FoodServiceTest {
 
         //when
         BaseNutrition testChangedBaseNutrition = BaseNutrition.createNutrition(2,3,4,5);
-        foodService.updateFavoriteFood(UpdateFavoriteFoodDto.of(favoriteFood.getId(), "testChangedFood", testChangedBaseNutrition));
+        foodService.updateFavoriteFood(UpdateFavoriteFoodDto.of(favoriteFood.getId(), 1L,"testChangedFood", testChangedBaseNutrition));
 
         assertEquals("testChangedFood", favoriteFood.getName());
         assertEquals(2,favoriteFood.getBaseNutrition().getKcal());
@@ -172,7 +172,7 @@ class FoodServiceTest {
         given(favoriteFoodRepository.existsById(favoriteFood.getId())).willReturn(true);
 
         //when
-        foodService.deleteFavoriteFood(favoriteFood.getId());
+        foodService.deleteFavoriteFood(favoriteFood.getId(), user.getId());
 
         verify(favoriteFoodRepository, times(1)).deleteById(favoriteFood.getId());
     }

--- a/src/test/java/com/diareat/diareat/service/FoodServiceTest.java
+++ b/src/test/java/com/diareat/diareat/service/FoodServiceTest.java
@@ -57,7 +57,7 @@ class FoodServiceTest {
         User user = User.createUser("testUser", "testImage","testPassword", 1,180, 80,18, testBaseNutrition);
         user.setId(1L);
 
-        CreateFoodDto createFoodDto = CreateFoodDto.of(user.getId(), "testFood", testBaseNutrition);
+        CreateFoodDto createFoodDto = CreateFoodDto.of(user.getId(), "testFood", testBaseNutrition, LocalDate.now());
         Food food = Food.createFood("testFood", user, testBaseNutrition);
         food.setId(2L);
 

--- a/src/test/java/com/diareat/diareat/service/FoodServiceTest.java
+++ b/src/test/java/com/diareat/diareat/service/FoodServiceTest.java
@@ -98,7 +98,7 @@ class FoodServiceTest {
         assertEquals(4,food.getBaseNutrition().getProtein());
         assertEquals(5,food.getBaseNutrition().getFat());
     }
-//
+    //
     @Test
     void testDeleteFood() {
         //given
@@ -108,9 +108,10 @@ class FoodServiceTest {
         food.setId(1L);
 
         given(foodRepository.existsById(food.getId())).willReturn(true);
+        given(foodRepository.existsByIdAndUserId(food.getId(), 1L)).willReturn(true);
 
         //when
-        foodService.deleteFood(food.getId(), user.getId());
+        foodService.deleteFood(food.getId(), 1L);
 
         verify(foodRepository, times(1)).deleteById(food.getId());
     }
@@ -160,7 +161,7 @@ class FoodServiceTest {
         assertEquals(4,favoriteFood.getBaseNutrition().getProtein());
         assertEquals(5,favoriteFood.getBaseNutrition().getFat());
     }
-//
+    //
     @Test
     void testDeleteFavoriteFood() {
         //given
@@ -170,13 +171,14 @@ class FoodServiceTest {
         favoriteFood.setId(1L);
 
         given(favoriteFoodRepository.existsById(favoriteFood.getId())).willReturn(true);
+        given(favoriteFoodRepository.existsByIdAndUserId(favoriteFood.getId(), 1L)).willReturn(true);
 
         //when
-        foodService.deleteFavoriteFood(favoriteFood.getId(), user.getId());
+        foodService.deleteFavoriteFood(favoriteFood.getId(), 1L);
 
         verify(favoriteFoodRepository, times(1)).deleteById(favoriteFood.getId());
     }
-//
+    //
     @Test
     void testNutritionSumByDate(){
         //given
@@ -203,7 +205,7 @@ class FoodServiceTest {
         assertEquals(Math.round((((double)200 / (double)80) * 100.0)*100.0)/100.0, responseNutritionSumByDateDto.getRatioProtein());
         assertEquals(Math.round((((double)250 / (double)80) * 100.0)*100.0)/100.0, responseNutritionSumByDateDto.getRatioFat());
     }
-//
+    //
     @Test
     void testNutritionSumByWeek(){
         //given
@@ -261,7 +263,7 @@ class FoodServiceTest {
         assertEquals(Math.round((((double)250 / (double)80) * 100.0)*100.0)/100.0, responseNutritionSumByDateDto.getRatioFat());
 
     }
-//
+    //
     @Test
     void getBest3FoodTest() {
         // given
@@ -288,7 +290,7 @@ class FoodServiceTest {
         assertEquals("Food2", top3Foods.get(1).getName());
         assertEquals("Food3", top3Foods.get(2).getName());
     }
-//
+    //
     @Test
     void getWorst3FoodsTest() {
         // given


### PR DESCRIPTION
https://github.com/CAUSOLDOUTMEN/Diareat_backend/pull/45

# 추가 작업
* 음식/즐찾음식 수정 Dto에 userId 속성 추가
* CreateFoodDto에 date 속성 추가 (특정 날짜의 음식 조회 데이터 캐싱 일관성 부여)
* 음식/즐찾음식 삭제 기능의 validate 함수 추가적인 유효성검사 적용 (유저가 이 음식을 "소유"하고 있는 관계가 맞는지 판정하는 과정 추가)
* 이를 위해 음식/즐찾음식 삭제(해제) 요청에 클라가 RequestHeader 에 userId 속성 담아 서버로 보내는 제약 추가
* FoodService 캐싱 적용
* 음식/즐찾음식 생성인데 왜 CacheEvict인가요? -> 메모리는 새로 추가된 상황을 모르고 있기 때문에