### PR TITLE
Fix: 카카오로그인 에러 수정 (#51)

### DIFF
--- a/src/main/java/com/diareat/diareat/auth/dto/KakaoAccount.java
+++ b/src/main/java/com/diareat/diareat/auth/dto/KakaoAccount.java
@@ -5,5 +5,7 @@ import lombok.Getter;
 @Getter
 public class KakaoAccount {
 
+    private Boolean profile_nickname_needs_agreement;
+    private Boolean profile_image_needs_agreement;
     private KakaoProfile profile;
 }

--- a/src/main/java/com/diareat/diareat/auth/dto/KakaoProfile.java
+++ b/src/main/java/com/diareat/diareat/auth/dto/KakaoProfile.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 public class KakaoProfile {
 
     private String nickname;
-    private String profileImageUrl;
-    private String thumbnailImageUrl;
-    private boolean isDefaultImage;
+    private String thumbnail_image_url;
+    private String profile_image_url;
+    private Boolean is_default_image;
 }

--- a/src/main/java/com/diareat/diareat/auth/dto/KakaoProperties.java
+++ b/src/main/java/com/diareat/diareat/auth/dto/KakaoProperties.java
@@ -1,0 +1,11 @@
+package com.diareat.diareat.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoProperties {
+
+    private String nickname;
+    private String profile_image;
+    private String thumbnail_image;
+}

--- a/src/main/java/com/diareat/diareat/auth/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/com/diareat/diareat/auth/dto/KakaoUserInfoResponse.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public class KakaoUserInfoResponse {
 
     private Long id;
-    private boolean hasSignedUp;
-    private KakaoAccount kakaoAccount;
+    private String connected_at;
+    private KakaoProperties properties;
+    private KakaoAccount kakao_account;
 }

--- a/src/main/java/com/diareat/diareat/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/diareat/diareat/auth/service/KakaoAuthService.java
@@ -29,7 +29,7 @@ public class KakaoAuthService {
     @Transactional(readOnly = true)
     public CreateUserDto createUserDto(JoinUserDto joinUserDto) { // 카카오로부터 프사 URL, 유저 고유ID를 얻어온 후, 이를 유저가 입력한 정보와 함께 CreateUserDto로 반환
         KakaoUserInfoResponse userInfo = kakaoUserInfo.getUserInfo(joinUserDto.getToken());
-        return CreateUserDto.of(joinUserDto.getNickName(), userInfo.getKakaoAccount().getProfile().getProfileImageUrl(),
+        return CreateUserDto.of(joinUserDto.getNickName(), userInfo.getKakao_account().getProfile().getProfile_image_url(),
                 userInfo.getId().toString(), joinUserDto.getGender(), joinUserDto.getHeight(), joinUserDto.getWeight(), joinUserDto.getAge());
     }
 }


### PR DESCRIPTION
* 타임리프를 통해 클라이언트 입장에서의 카카오로그인을 실제로 시도
<img width="1166" alt="image" src="https://github.com/CAUSOLDOUTMEN/Diareat_backend/assets/53044069/f0caebb8-7c13-413d-a6d4-5dbd17b5ecff">

* 프사 url에 대해 접근 시 return 과정에서 NullPointerException 발생
* 확인 결과 서버에 accessToken을 전송했을 때 반환 JSON은 아래와 같았음

```java
{
    "id": Long,
    "connected_at": "string",
    "properties": {
        "nickname": "string",
        "profile_image": "string",
        "thumbnail_image": "string"
    },
    "kakao_account": {
        "profile_nickname_needs_agreement": false,
        "profile_image_needs_agreement": false,
        "profile": {
            "nickname": "string",
            "thumbnail_image_url": "string",
            "profile_image_url": "string",
            "is_default_image": false
        }
    }
}
```

* 초기 설정한 Dto는 카멜 케이스였고, 카카오 서버에서 반환하는 JSON은 스네이크 케이스
* getter에서 표현의 차이로 미스매칭이 발생
* Dto를 모두 스네이크 케이스로 통일
* /api/auth/join 실행 시 성공적으로 동작하는 것을 확인함

```java
{
    "header": {
        "code": 200,
        "message": "SUCCESS"
    },
    "data": {
        "1": "string"
    },
    "msg": "사용자 생성 성공"
}
```
