### PR TITLE
Fix: ResponseFoodDto Date/Time 타입 주석처리 (#66)

### DIFF
--- a/src/main/java/com/diareat/diareat/food/dto/ResponseFoodDto.java
+++ b/src/main/java/com/diareat/diareat/food/dto/ResponseFoodDto.java
@@ -15,16 +15,16 @@ public class ResponseFoodDto {
     private Long foodId;
     private Long userId;
     private String name;
-    private LocalDate date;
-    private LocalTime time;
+    //private LocalDate date;
+    //private LocalTime time;
     private BaseNutrition baseNutrition;
     private boolean isFavorite;
 
     public static ResponseFoodDto of(Long foodId, Long userId, String name, LocalDate date, LocalTime time, BaseNutrition baseNutrition, boolean isFavorite) {
-        return new ResponseFoodDto(foodId, userId, name, date, time, baseNutrition, isFavorite);
+        return new ResponseFoodDto(foodId, userId, name, baseNutrition, isFavorite);
     }
 
     public static ResponseFoodDto from(Food food) {
-        return new ResponseFoodDto(food.getId(), food.getUser().getId(), food.getName(), food.getDate(), food.getTime(), food.getBaseNutrition(), food.isFavorite());
+        return new ResponseFoodDto(food.getId(), food.getUser().getId(), food.getName(), food.getBaseNutrition(), food.isFavorite());
     }
 }

--- a/src/test/java/com/diareat/diareat/controller/FoodControllerTest.java
+++ b/src/test/java/com/diareat/diareat/controller/FoodControllerTest.java
@@ -117,7 +117,7 @@ public class FoodControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.header.code").value(expectedResponse.getHeader().getCode()))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.header.message").value(expectedResponse.getHeader().getMessage()))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].name").value(expectedResponse.getData().get(0).getName()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].date").value(expectedResponse.getData().get(0).getDate().toString()))
+                //.andExpect(MockMvcResultMatchers.jsonPath("$.data[0].date").value(expectedResponse.getData().get(0).getDate().toString()))
                 //.andExpect(MockMvcResultMatchers.jsonPath("$.data[0].time").value(expectedResponse.getData().get(0).getTime().toString()))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].baseNutrition.kcal").value(expectedResponse.getData().get(0).getBaseNutrition().getKcal()))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].baseNutrition.carbohydrate").value(expectedResponse.getData().get(0).getBaseNutrition().getCarbohydrate()))


### PR DESCRIPTION
* 오후에 발생한 문제와 동일하게, ResponseDto에 LocalDate/Time 타입이 존재할 경우 직렬화 오류 발생
* 임시 주석처리