### PR TITLE
Fix: Redis 캐시 일관성 손실 문제 해결 (#84)

### DIFF
--- a/src/main/java/com/diareat/diareat/food/controller/FoodController.java
+++ b/src/main/java/com/diareat/diareat/food/controller/FoodController.java
@@ -7,7 +7,6 @@ import com.diareat.diareat.util.api.ApiResponse;
 import com.diareat.diareat.util.api.ResponseCode;
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -45,15 +44,23 @@ public class FoodController {
     //음식 정보 수정
     @Operation(summary = "[음식] 음식 정보 수정",description = "음식에 대한 정보를 수정합니다.")
     @PostMapping("/update")
-    public ApiResponse<Void> updateFood(@RequestBody @Valid UpdateFoodDto updateFoodDto){
-        foodService.updateFood(updateFoodDto);
+    public ApiResponse<Void> updateFood(@RequestBody @Valid UpdateFoodDto updateFoodDto,
+                                        @RequestParam int yy,
+                                        @RequestParam int mm,
+                                        @RequestParam int dd){
+        LocalDate date = LocalDate.of(yy,mm,dd);
+        foodService.updateFood(updateFoodDto, date);
         return ApiResponse.success(null,ResponseCode.FOOD_UPDATE_SUCCESS.getMessage());
     }
     //음식 삭제
     @Operation(summary = "[음식] 음식 정보 삭제",description = "음식에 대한 정보를 삭제합니다.")
     @DeleteMapping("/{foodId}/delete")
-    public ApiResponse<Void> deleteFood(@PathVariable Long foodId, @RequestHeader Long userId){
-        foodService.deleteFood(foodId, userId);
+    public ApiResponse<Void> deleteFood(@PathVariable Long foodId, @RequestHeader Long userId,
+                                        @RequestParam int yy,
+                                        @RequestParam int mm,
+                                        @RequestParam int dd){
+        LocalDate date = LocalDate.of(yy,mm,dd);
+        foodService.deleteFood(foodId, userId, date);
         return ApiResponse.success(null, ResponseCode.FOOD_DELETE_SUCCESS.getMessage());
     }
 

--- a/src/main/java/com/diareat/diareat/food/dto/ResponseAnalysisDto.java
+++ b/src/main/java/com/diareat/diareat/food/dto/ResponseAnalysisDto.java
@@ -2,10 +2,12 @@ package com.diareat.diareat.food.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class ResponseAnalysisDto { // 그래프 + 점수에 사용되는 DTO
 

--- a/src/main/java/com/diareat/diareat/food/dto/ResponseFavoriteFoodDto.java
+++ b/src/main/java/com/diareat/diareat/food/dto/ResponseFavoriteFoodDto.java
@@ -4,8 +4,10 @@ import com.diareat.diareat.food.domain.FavoriteFood;
 import com.diareat.diareat.user.domain.BaseNutrition;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class ResponseFavoriteFoodDto {
 

--- a/src/main/java/com/diareat/diareat/food/dto/ResponseFoodRankDto.java
+++ b/src/main/java/com/diareat/diareat/food/dto/ResponseFoodRankDto.java
@@ -1,15 +1,14 @@
 package com.diareat.diareat.food.dto;
 
-import com.diareat.diareat.food.domain.Food;
-import com.diareat.diareat.user.domain.BaseNutrition;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class ResponseFoodRankDto {
 

--- a/src/main/java/com/diareat/diareat/food/dto/ResponseScoreBestWorstDto.java
+++ b/src/main/java/com/diareat/diareat/food/dto/ResponseScoreBestWorstDto.java
@@ -2,10 +2,12 @@ package com.diareat.diareat.food.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class ResponseScoreBestWorstDto { // 일기 분석 자세히보기에 사용되는 DTO
 

--- a/src/main/java/com/diareat/diareat/food/dto/ResponseSimpleFoodDto.java
+++ b/src/main/java/com/diareat/diareat/food/dto/ResponseSimpleFoodDto.java
@@ -3,10 +3,12 @@ package com.diareat.diareat.food.dto;
 import com.diareat.diareat.food.domain.Food;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class ResponseSimpleFoodDto { // Best 3 and Worst 3에 사용될 객체
 

--- a/src/main/java/com/diareat/diareat/food/service/FoodService.java
+++ b/src/main/java/com/diareat/diareat/food/service/FoodService.java
@@ -10,6 +10,7 @@ import com.diareat.diareat.user.domain.User;
 import com.diareat.diareat.user.dto.response.ResponseRankUserDto;
 import com.diareat.diareat.user.repository.FollowRepository;
 import com.diareat.diareat.user.repository.UserRepository;
+import com.diareat.diareat.util.MessageUtil;
 import com.diareat.diareat.util.api.ResponseCode;
 import com.diareat.diareat.util.exception.FavoriteException;
 import com.diareat.diareat.util.exception.FoodException;
@@ -36,7 +37,7 @@ public class FoodService {
     private final UserRepository userRepository;
 
     // 촬영 후, 음식 정보 저장
-    @CacheEvict(value = "ResponseFoodDto", key = "#createFoodDto.getUserId()+#createFoodDto.getDate().toString()", cacheManager = "diareatCacheManager")
+    @CacheEvict(value = "ResponseFoodDto, ResponseNutritionSumByDateDto", key = "#createFoodDto.getUserId()+#createFoodDto.getDate().toString()", cacheManager = "diareatCacheManager")
     @Transactional
     public Long saveFood(CreateFoodDto createFoodDto) {
         if (foodRepository.existsByName(createFoodDto.getName())){
@@ -52,25 +53,25 @@ public class FoodService {
     @Transactional(readOnly = true)
     public List<ResponseFoodDto> getFoodListByDate(Long userId, LocalDate date){
         validateUser(userId);
-        Sort sort = Sort.by(Sort.Direction.DESC, "addedTime");
+        Sort sort = Sort.by(Sort.Direction.DESC, MessageUtil.TIME_STAMP);
         List<Food> foodList = foodRepository.findAllByUserIdAndDate(userId, date, sort);
         return foodList.stream()
                 .map(food -> ResponseFoodDto.of(food.getId(), food.getUser().getId(), food.getName(), food.getBaseNutrition(), food.isFavorite())).collect(Collectors.toList());
     }
 
     // 음식 정보 수정
-    @CacheEvict(value = "ResponseFoodDto", key = "#updateFoodDto.getUserId()", cacheManager = "diareatCacheManager")
+    @CacheEvict(value = "ResponseFoodDto, ResponseNutritionSumByDateDto", key = "#updateFoodDto.getUserId()+date.toString()", cacheManager = "diareatCacheManager")
     @Transactional
-    public void updateFood(UpdateFoodDto updateFoodDto) {
+    public void updateFood(UpdateFoodDto updateFoodDto, LocalDate date) {
         Food food = getFoodById(updateFoodDto.getFoodId());
         food.updateFood(updateFoodDto.getName(), updateFoodDto.getBaseNutrition());
         foodRepository.save(food);
     }
 
     // 음식 삭제
-    @CacheEvict(value = "ResponseFoodDto", key = "#userId", cacheManager = "diareatCacheManager")
+    @CacheEvict(value = "ResponseFoodDto, ResponseNutritionSumByDateDto", key = "#userId+date.toString()", cacheManager = "diareatCacheManager")
     @Transactional
-    public void deleteFood(Long foodId, Long userId) {
+    public void deleteFood(Long foodId, Long userId, LocalDate date) {
         validateFood(foodId, userId);
         foodRepository.deleteById(foodId);
     }
@@ -119,7 +120,7 @@ public class FoodService {
     // 유저의 특정 날짜에 먹은 음식들의 영양성분별 총합 조회 (섭취영양소/기준영양소 및 비율까지 계산해서 반환, dto 구체적 협의 필요)
     public ResponseNutritionSumByDateDto getNutritionSumByDate(Long userId, LocalDate date) {
         validateUser(userId);
-        Sort sort = Sort.by(Sort.Direction.DESC, "addedTime");
+        Sort sort = Sort.by(Sort.Direction.DESC, MessageUtil.TIME_STAMP);
         List<Food> foodList = foodRepository.findAllByUserIdAndDate(userId, date, sort);
         return calculateNutritionSumAndRatio(userId, foodList, date, 1);
     }
@@ -129,7 +130,7 @@ public class FoodService {
     public ResponseNutritionSumByDateDto getNutritionSumByWeek(Long userId) {
         validateUser(userId);
         LocalDate endDate = LocalDate.now();
-        Sort sort = Sort.by(Sort.Direction.DESC, "addedTime");
+        Sort sort = Sort.by(Sort.Direction.DESC, MessageUtil.TIME_STAMP);
         List<Food> foodList = foodRepository.findAllByUserIdAndDateBetween(userId, endDate.minusWeeks(1), endDate, sort);
 
         return calculateNutritionSumAndRatio(userId, foodList, endDate, 7);
@@ -140,7 +141,7 @@ public class FoodService {
     public ResponseNutritionSumByDateDto getNutritionSumByMonth(Long userId) {
         validateUser(userId);
         LocalDate endDate = LocalDate.now();
-        Sort sort = Sort.by(Sort.Direction.DESC, "addedTime");
+        Sort sort = Sort.by(Sort.Direction.DESC, MessageUtil.TIME_STAMP);
         List<Food> foodList = foodRepository.findAllByUserIdAndDateBetween(userId, endDate.minusMonths(1), endDate, sort);
 
         return calculateNutritionSumAndRatio(userId, foodList, endDate, 30);
@@ -151,7 +152,7 @@ public class FoodService {
     public ResponseFoodRankDto getBestFoodByWeek(Long userId) {
         validateUser(userId);
         LocalDate endDate = LocalDate.now();
-        Sort sort = Sort.by(Sort.Direction.DESC, "addedTime");
+        Sort sort = Sort.by(Sort.Direction.DESC, MessageUtil.TIME_STAMP);
         List<Food> foodList = foodRepository.findAllByUserIdAndDateBetween(userId, endDate.minusWeeks(1), endDate, sort);
 
         List<Food> top3Foods = foodList.stream()
@@ -174,7 +175,7 @@ public class FoodService {
     public ResponseFoodRankDto getWorstFoodByWeek(Long userId) {
         validateUser(userId);
         LocalDate endDate = LocalDate.now();
-        Sort sort = Sort.by(Sort.Direction.DESC, "addedTime");
+        Sort sort = Sort.by(Sort.Direction.DESC, MessageUtil.TIME_STAMP);
         List<Food> foodList = foodRepository.findAllByUserIdAndDateBetween(userId, endDate.minusWeeks(1), endDate, sort);
 
         List<Food> worst3Foods = foodList.stream()
@@ -402,7 +403,7 @@ public class FoodService {
     // 1주일동안 먹은 음식들의 영양성분 총합을 요일을 Key로 한 Map을 통해 반환
     private HashMap<LocalDate, List<BaseNutrition>> getNutritionSumByDateMap(Long userId, LocalDate startDate, LocalDate endDate) {
         HashMap<LocalDate, List<BaseNutrition>> maps = new HashMap<>();
-        Sort sort = Sort.by(Sort.Direction.DESC, "addedTime");
+        Sort sort = Sort.by(Sort.Direction.DESC, MessageUtil.TIME_STAMP);
         List<Food> foodList = foodRepository.findAllByUserIdAndDateBetween(userId, startDate, endDate, sort);
         for (Food food : foodList) {
             if (maps.containsKey(food.getDate())) {

--- a/src/main/java/com/diareat/diareat/user/dto/response/ResponseSimpleUserDto.java
+++ b/src/main/java/com/diareat/diareat/user/dto/response/ResponseSimpleUserDto.java
@@ -9,9 +9,8 @@ public class ResponseSimpleUserDto {
 
     private String name;
     private String image;
-    private double nutritionScore;
 
-    public static ResponseSimpleUserDto of(String name, String image, double nutritionScore) {
-        return new ResponseSimpleUserDto(name, image, nutritionScore);
+    public static ResponseSimpleUserDto of(String name, String image) {
+        return new ResponseSimpleUserDto(name, image);
     }
 }

--- a/src/main/java/com/diareat/diareat/user/service/UserService.java
+++ b/src/main/java/com/diareat/diareat/user/service/UserService.java
@@ -65,7 +65,7 @@ public class UserService {
     }
 
     // 회원정보 수정
-    @CacheEvict(value = {"ResponseSimpleUserDto", "ResponseUserDto"}, key = "#updateUserDto.userId", cacheManager = "diareatCacheManager")
+    @CacheEvict(value = {"ResponseSimpleUserDto", "ResponseUserDto"}, key = "#updateUserDto.getUserId()", cacheManager = "diareatCacheManager")
     @Transactional
     public void updateUserInfo(UpdateUserDto updateUserDto) {
         User user = getUserById(updateUserDto.getUserId());
@@ -83,7 +83,7 @@ public class UserService {
     }
 
     // 회원 기준섭취량 직접 수정
-    @CacheEvict(value = "ResponseUserNutritionDto", key = "#updateUserNutritionDto.userId", cacheManager = "diareatCacheManager")
+    @CacheEvict(value = "ResponseUserNutritionDto", key = "#updateUserNutritionDto.getUserId()", cacheManager = "diareatCacheManager")
     @Transactional
     public void updateBaseNutrition(UpdateUserNutritionDto updateUserNutritionDto) {
         User user = getUserById(updateUserNutritionDto.getUserId());

--- a/src/main/java/com/diareat/diareat/user/service/UserService.java
+++ b/src/main/java/com/diareat/diareat/user/service/UserService.java
@@ -52,8 +52,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public ResponseSimpleUserDto getSimpleUserInfo(Long userId) {
         User user = getUserById(userId);
-        double nutritionScore = 100; // 점수 계산 로직 확정 전 기본값 -> 추후 수정 필요
-        return ResponseSimpleUserDto.of(user.getName(), user.getImage(), nutritionScore);
+        return ResponseSimpleUserDto.of(user.getName(), user.getImage());
     }
 
     // 회원정보 조회

--- a/src/main/java/com/diareat/diareat/util/MessageUtil.java
+++ b/src/main/java/com/diareat/diareat/util/MessageUtil.java
@@ -20,4 +20,5 @@ public class MessageUtil { // 반복되는 메시지의 형식을 저장하고 �
     public static final String FAT_RANGE = "지방은 25 이상, 500 이하의 값을 입력해주세요.";
 
     public static final String PAST_OR_PRESENT = "과거 또는 오늘 날짜여야 합니다.";
+    public static final String TIME_STAMP = "addedTime";
 }

--- a/src/test/java/com/diareat/diareat/controller/FoodControllerTest.java
+++ b/src/test/java/com/diareat/diareat/controller/FoodControllerTest.java
@@ -27,14 +27,13 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @WebMvcTest(controllers = FoodController.class)
-public class FoodControllerTest {
+class FoodControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -131,12 +130,20 @@ public class FoodControllerTest {
     @WithMockUser("test")
     void testUpdateFood() throws Exception {
         //Given
+        int yy = 2023;
+        int dd = 22;
+        int mm = 12;
+        LocalDate date = LocalDate.of(yy, mm, dd);
+
         ApiResponse<Void> expectedResponse = ApiResponse.success(null, ResponseCode.FOOD_UPDATE_SUCCESS.getMessage());
         UpdateFoodDto updateFoodDto = UpdateFoodDto.of(testFoodId, testUserId, "testFood", testBaseNutrition);
         String json = mapper.writeValueAsString(updateFoodDto);
 
         mockMvc.perform(MockMvcRequestBuilders
                         .post("/api/food/update")
+                        .param("yy", String.valueOf(date.getYear()))
+                        .param("mm", String.valueOf(date.getMonthValue()))
+                        .param("dd", String.valueOf(date.getDayOfMonth()))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json)
                         .accept(MediaType.APPLICATION_JSON))
@@ -152,10 +159,18 @@ public class FoodControllerTest {
     @WithMockUser("test")
     void testDeleteFood() throws Exception {
         //Given
+        int yy = 2023;
+        int dd = 22;
+        int mm = 12;
+        LocalDate date = LocalDate.of(yy, mm, dd);
+
         ApiResponse<Void> expectedResponse = ApiResponse.success(null, ResponseCode.FOOD_DELETE_SUCCESS.getMessage());
 
         mockMvc.perform(MockMvcRequestBuilders
                         .delete("/api/food/{foodId}/delete", testFoodId)
+                        .param("yy", String.valueOf(date.getYear()))
+                        .param("mm", String.valueOf(date.getMonthValue()))
+                        .param("dd", String.valueOf(date.getDayOfMonth()))
                         .header("userId", testUserId)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().isOk())

--- a/src/test/java/com/diareat/diareat/controller/UserControllerTest.java
+++ b/src/test/java/com/diareat/diareat/controller/UserControllerTest.java
@@ -59,7 +59,7 @@ class UserControllerTest {
     void setUp() {
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
         testUser.setId(testUserId);
-        when(userService.getSimpleUserInfo(testUserId)).thenReturn(ResponseSimpleUserDto.of(testUser.getName(), testUser.getImage(), 100.0));
+        when(userService.getSimpleUserInfo(testUserId)).thenReturn(ResponseSimpleUserDto.of(testUser.getName(), testUser.getImage()));
         when(userService.getUserInfo(testUserId)).thenReturn(ResponseUserDto.from(testUser));
     }
 
@@ -69,7 +69,7 @@ class UserControllerTest {
     void testGetSimpleUserInfo() throws Exception {
         // Given
         ApiResponse<ResponseSimpleUserDto> expectedResponse = ApiResponse.success(
-                ResponseSimpleUserDto.of(testUser.getName(), testUser.getImage(), 100.0), ResponseCode.USER_CREATE_SUCCESS.getMessage());
+                ResponseSimpleUserDto.of(testUser.getName(), testUser.getImage()), ResponseCode.USER_CREATE_SUCCESS.getMessage());
 
         // When & Then
         mockMvc.perform( MockMvcRequestBuilders
@@ -79,8 +79,7 @@ class UserControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.header.code").value(expectedResponse.getHeader().getCode()))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.header.message").value(expectedResponse.getHeader().getMessage()))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.name").value(expectedResponse.getData().getName()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value(expectedResponse.getData().getImage()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nutritionScore").value(expectedResponse.getData().getNutritionScore()));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image").value(expectedResponse.getData().getImage()));
     }
 
     @DisplayName("회원정보 조회")

--- a/src/test/java/com/diareat/diareat/service/FoodServiceTest.java
+++ b/src/test/java/com/diareat/diareat/service/FoodServiceTest.java
@@ -9,7 +9,6 @@ import com.diareat.diareat.food.service.FoodService;
 import com.diareat.diareat.user.domain.BaseNutrition;
 import com.diareat.diareat.user.domain.User;
 import com.diareat.diareat.user.dto.response.ResponseRankUserDto;
-import com.diareat.diareat.user.dto.response.ResponseSimpleUserDto;
 import com.diareat.diareat.user.repository.FollowRepository;
 import com.diareat.diareat.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -92,7 +91,7 @@ class FoodServiceTest {
 
         //when
         BaseNutrition testChangedBaseNutrition = BaseNutrition.createNutrition(2,3,4,5);
-        foodService.updateFood(UpdateFoodDto.of(food.getId(), 1L,"testChangedFood", testChangedBaseNutrition));
+        foodService.updateFood(UpdateFoodDto.of(food.getId(), 1L,"testChangedFood", testChangedBaseNutrition), LocalDate.of(2010, 1, 1));
 
 
         assertEquals("testChangedFood", food.getName());
@@ -114,7 +113,7 @@ class FoodServiceTest {
         given(foodRepository.existsByIdAndUserId(food.getId(), 1L)).willReturn(true);
 
         //when
-        foodService.deleteFood(food.getId(), 1L);
+        foodService.deleteFood(food.getId(), 1L, LocalDate.of(2010, 1, 1));
 
         verify(foodRepository, times(1)).deleteById(food.getId());
     }


### PR DESCRIPTION
* 음식 수정 및 삭제 시 해당 음식의 날짜에 해당하는 음식 Dto 캐시에서 삭제하는 기능 누락
* 이를 위해 Controller에서 클라이언트가 제공하는 yy-mm-dd 값을 활용
* ResponseSimpleDto 더미 영양점수 삭제 (클라이언트와 협의 완료)
* user 패키지에 주요 Dto 기본생성자 추가
* 반복되는 addedTime 문자열 MessageUtil에서 단일 관리
* 불필요한 import 정리 및 테스트코드 변경