### PR TITLE
Fix: 캐싱 value 일부 수정 (#92)

### DIFF
--- a/src/main/java/com/diareat/diareat/food/service/FoodService.java
+++ b/src/main/java/com/diareat/diareat/food/service/FoodService.java
@@ -37,7 +37,7 @@ public class FoodService {
     private final UserRepository userRepository;
 
     // 촬영 후, 음식 정보 저장
-    @CacheEvict(value = {"ResponseNutritionSumByDateDto"}, key = "#userId+date.toString()", cacheManager = "diareatCacheManager")
+    @CacheEvict(value = {"ResponseNutritionSumByDateDto"}, key = "#userId+createFoodDto.getDate()", cacheManager = "diareatCacheManager")
     @Transactional
     public Long saveFood(CreateFoodDto createFoodDto) {
         if (foodRepository.existsByName(createFoodDto.getName())){

--- a/src/main/java/com/diareat/diareat/food/service/FoodService.java
+++ b/src/main/java/com/diareat/diareat/food/service/FoodService.java
@@ -37,6 +37,7 @@ public class FoodService {
     private final UserRepository userRepository;
 
     // 촬영 후, 음식 정보 저장
+    @CacheEvict(value = {"ResponseNutritionSumByDateDto"}, key = "#userId+date.toString()", cacheManager = "diareatCacheManager")
     @Transactional
     public Long saveFood(CreateFoodDto createFoodDto) {
         if (foodRepository.existsByName(createFoodDto.getName())){
@@ -47,7 +48,7 @@ public class FoodService {
         return foodRepository.save(food).getId();
     }
 
-    // 회원이 특정 날짜에 먹은 음식 조회
+    // 회원이 특정 날짜에 먹은 음식 조회 -> 돌발적인 행동이 많아 캐시 일관성 유지의 가치가 낮아서 캐싱 배제
     @Transactional(readOnly = true)
     public List<ResponseFoodDto> getFoodListByDate(Long userId, LocalDate date){
         validateUser(userId);
@@ -58,7 +59,7 @@ public class FoodService {
     }
 
     // 음식 정보 수정
-    @CacheEvict(value = "ResponseFoodDto, ResponseNutritionSumByDateDto", key = "#updateFoodDto.getUserId()+date.toString()", cacheManager = "diareatCacheManager")
+    @CacheEvict(value = {"ResponseNutritionSumByDateDto"}, key = "#updateFoodDto.getUserId()+date.toString()", cacheManager = "diareatCacheManager")
     @Transactional
     public void updateFood(UpdateFoodDto updateFoodDto, LocalDate date) {
         Food food = getFoodById(updateFoodDto.getFoodId());
@@ -67,7 +68,7 @@ public class FoodService {
     }
 
     // 음식 삭제
-    @CacheEvict(value = "ResponseFoodDto, ResponseNutritionSumByDateDto", key = "#userId+date.toString()", cacheManager = "diareatCacheManager")
+    @CacheEvict(value = {"ResponseNutritionSumByDateDto"}, key = "#userId+date.toString()", cacheManager = "diareatCacheManager")
     @Transactional
     public void deleteFood(Long foodId, Long userId, LocalDate date) {
         validateFood(foodId, userId);


### PR DESCRIPTION
* 즐겨찾기에 음식 추가 기능은 현재 날짜 음식 조회 캐싱데이터의 초기화를 필요로 하는데, 즐겨찾기 관련 응답 데이터의 key에 date 속성이 들어갈 수 없어, 현재 날짜 음식 조회의 캐싱을 배제
* 기타 잘못된 RedisCache value 표기 수정