### PR TITLE
Fix: 즐겨찾기 버그 수정을 위한 음식-즐겨찾는음식 연관관계 개편 (#114)

### DIFF
--- a/src/main/java/com/diareat/diareat/food/domain/FavoriteFood.java
+++ b/src/main/java/com/diareat/diareat/food/domain/FavoriteFood.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,9 +22,10 @@ public class FavoriteFood {
 
     private String name;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST}, orphanRemoval = false) // 즐찾음식이 삭제되어도 음식은 삭제되지 않음
-    @JoinColumn(name = "food_id")
-    private Food food;
+    //@OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST}, orphanRemoval = false) // 즐찾음식이 삭제되어도 음식은 삭제되지 않음
+    //@JoinColumn(name = "food_id")
+    @OneToMany(mappedBy = "favoriteFood", cascade = CascadeType.PERSIST, orphanRemoval = false) // 즐찾음식이 삭제되어도 음식은 삭제되지 않음
+    private List<Food> foods = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -40,10 +43,10 @@ public class FavoriteFood {
     public static FavoriteFood createFavoriteFood(String name, User user, Food food, BaseNutrition baseNutrition) {
         FavoriteFood favoriteFood = new FavoriteFood();
         favoriteFood.name = name;
-        favoriteFood.food = food;
+        favoriteFood.foods.add(food);
         favoriteFood.user = user;
         favoriteFood.baseNutrition = baseNutrition;
-        food.setFavoriteFood(favoriteFood);
+        //food.setFavoriteFood(favoriteFood); 관계의 주인이 즐겨찾기로 명확하게 정해졌기에 주석처리
         return favoriteFood;
     }
 

--- a/src/main/java/com/diareat/diareat/food/domain/Food.java
+++ b/src/main/java/com/diareat/diareat/food/domain/Food.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,7 +27,7 @@ public class Food {
 
     //@OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST}, orphanRemoval = false) // 음식이 삭제되어도 즐찾음식은 삭제되지 않음
     //@JoinColumn(name = "favorite_food_id")
-    @ManyToOne(fetch = FetchType.LAZY) // 다대일로 매핑하여 음식의 즐찾음식을 찾을 수 있도록 함
+    @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST}) // 다대일로 매핑하여 음식의 즐찾음식을 찾을 수 있도록 함
     @JoinColumn(name = "favorite_food_id")
     private FavoriteFood favoriteFood;
 

--- a/src/main/java/com/diareat/diareat/food/domain/Food.java
+++ b/src/main/java/com/diareat/diareat/food/domain/Food.java
@@ -26,7 +26,9 @@ public class Food {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST}, orphanRemoval = false) // 음식이 삭제되어도 즐찾음식은 삭제되지 않음
+    //@OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST}, orphanRemoval = false) // 음식이 삭제되어도 즐찾음식은 삭제되지 않음
+    //@JoinColumn(name = "favorite_food_id")
+    @ManyToOne(fetch = FetchType.LAZY) // 다대일로 매핑하여 음식의 즐찾음식을 찾을 수 있도록 함
     @JoinColumn(name = "favorite_food_id")
     private FavoriteFood favoriteFood;
 

--- a/src/main/java/com/diareat/diareat/food/repository/FavoriteFoodRepository.java
+++ b/src/main/java/com/diareat/diareat/food/repository/FavoriteFoodRepository.java
@@ -8,5 +8,4 @@ import java.util.List;
 public interface FavoriteFoodRepository extends JpaRepository<FavoriteFood, Long> {
     List<FavoriteFood> findAllByUserId(Long userId);
     boolean existsByIdAndUserId(Long id, Long userId); // 유저가 즐겨찾기에 추가한 음식인지 확인
-    boolean existsByFoodId(Long foodId); // 이미 즐겨찾기에 추가된 음식인지 확인하기 위함
 }

--- a/src/main/java/com/diareat/diareat/food/service/FoodService.java
+++ b/src/main/java/com/diareat/diareat/food/service/FoodService.java
@@ -86,6 +86,8 @@ public class FoodService {
             throw new FavoriteException(ResponseCode.FAVORITE_ALREADY_EXIST);
 
         FavoriteFood favoriteFood = FavoriteFood.createFavoriteFood(createFavoriteFoodDto.getName(), user, food, createFavoriteFoodDto.getBaseNutrition());
+        food.setFavoriteFood(favoriteFood);
+        foodRepository.save(food);
         return favoriteFoodRepository.save(favoriteFood).getId();
     }
 
@@ -302,6 +304,7 @@ public class FoodService {
     }
 
     @Transactional
+    // 즐겨찾기 음식으로부터 새로운 음식을 간편 등록
     public Long createFoodFromFavoriteFood(CreateFoodFromFavoriteFoodDto createFoodFromFavoriteFoodDto) {
         validateFavoriteFood(createFoodFromFavoriteFoodDto.getFavoriteFoodId(), createFoodFromFavoriteFoodDto.getUserId());
         FavoriteFood favoriteFood = getFavoriteFoodById(createFoodFromFavoriteFoodDto.getFavoriteFoodId());

--- a/src/main/java/com/diareat/diareat/food/service/FoodService.java
+++ b/src/main/java/com/diareat/diareat/food/service/FoodService.java
@@ -82,7 +82,7 @@ public class FoodService {
         User user = getUserById(createFavoriteFoodDto.getUserId());
         Food food = getFoodById(createFavoriteFoodDto.getFoodId());
 
-        if (favoriteFoodRepository.existsByFoodId(createFavoriteFoodDto.getFoodId()))
+        if (food.isFavorite())
             throw new FavoriteException(ResponseCode.FAVORITE_ALREADY_EXIST);
 
         FavoriteFood favoriteFood = FavoriteFood.createFavoriteFood(createFavoriteFoodDto.getName(), user, food, createFavoriteFoodDto.getBaseNutrition());

--- a/src/main/java/com/diareat/diareat/food/service/FoodService.java
+++ b/src/main/java/com/diareat/diareat/food/service/FoodService.java
@@ -82,7 +82,7 @@ public class FoodService {
         User user = getUserById(createFavoriteFoodDto.getUserId());
         Food food = getFoodById(createFavoriteFoodDto.getFoodId());
 
-        if (food.isFavorite())
+        if (food.isFavorite()) // 이미 즐겨찾기에 추가된 음식인 경우 중복 추가 불가능
             throw new FavoriteException(ResponseCode.FAVORITE_ALREADY_EXIST);
 
         FavoriteFood favoriteFood = FavoriteFood.createFavoriteFood(createFavoriteFoodDto.getName(), user, food, createFavoriteFoodDto.getBaseNutrition());

--- a/src/main/java/com/diareat/diareat/user/dto/request/JoinUserDto.java
+++ b/src/main/java/com/diareat/diareat/user/dto/request/JoinUserDto.java
@@ -4,6 +4,7 @@ import com.diareat.diareat.util.MessageUtil;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Range;
 
 import javax.validation.constraints.*;
 
@@ -18,20 +19,15 @@ public class JoinUserDto {
     @NotBlank(message = MessageUtil.NOT_BLANK)
     private String nickName;
 
-    @DecimalMin(value = "0", message = MessageUtil.GENDER_RANGE)
-    @DecimalMax(value = "1", message = MessageUtil.GENDER_RANGE)
+    @Range(min = 0, max = 1, message = MessageUtil.GENDER_RANGE)
     private int gender;
 
-    @DecimalMin(value = "100", message = MessageUtil.HEIGHT_RANGE)
-    @DecimalMax(value = "250", message = MessageUtil.HEIGHT_RANGE)
+    @Range(min = 100, max = 250, message = MessageUtil.HEIGHT_RANGE)
     private int height;
 
-    @DecimalMin(value = "30", message = MessageUtil.WEIGHT_RANGE)
-    @DecimalMax(value = "150", message = MessageUtil.WEIGHT_RANGE)
+    @Range(min = 30, max = 150, message = MessageUtil.WEIGHT_RANGE)
     private int weight;
 
-    @DecimalMin(value = "5", message = MessageUtil.AGE_RANGE)
-    @DecimalMax(value = "100", message = MessageUtil.AGE_RANGE)
+    @Range(min = 5, max = 100, message = MessageUtil.AGE_RANGE)
     private int age;
-
 }

--- a/src/main/java/com/diareat/diareat/user/dto/request/UpdateUserDto.java
+++ b/src/main/java/com/diareat/diareat/user/dto/request/UpdateUserDto.java
@@ -4,9 +4,8 @@ import com.diareat.diareat.util.MessageUtil;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Range;
 
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
@@ -21,16 +20,13 @@ public class UpdateUserDto {
     @NotBlank(message = MessageUtil.NOT_BLANK)
     private String name;
 
-    @DecimalMin(value = "100", message = MessageUtil.HEIGHT_RANGE)
-    @DecimalMax(value = "250", message = MessageUtil.HEIGHT_RANGE)
+    @Range(min = 100, max = 250, message = MessageUtil.HEIGHT_RANGE)
     private int height;
 
-    @DecimalMin(value = "30", message = MessageUtil.WEIGHT_RANGE)
-    @DecimalMax(value = "200", message = MessageUtil.WEIGHT_RANGE)
+    @Range(min = 30, max = 200, message = MessageUtil.WEIGHT_RANGE)
     private int weight;
 
-    @DecimalMin(value = "5", message = MessageUtil.AGE_RANGE)
-    @DecimalMax(value = "100", message = MessageUtil.AGE_RANGE)
+    @Range(min = 5, max = 100, message = MessageUtil.AGE_RANGE)
     private int age;
 
     private boolean isAutoUpdateNutrition; // 개인정보를 활용한 기준 영양소 자동계산 여부

--- a/src/main/java/com/diareat/diareat/user/dto/request/UpdateUserNutritionDto.java
+++ b/src/main/java/com/diareat/diareat/user/dto/request/UpdateUserNutritionDto.java
@@ -4,9 +4,8 @@ import com.diareat.diareat.util.MessageUtil;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Range;
 
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotNull;
 
 @Getter
@@ -17,20 +16,16 @@ public class UpdateUserNutritionDto {
     @NotNull(message = MessageUtil.NOT_NULL)
     private Long userId;
 
-    @DecimalMin(value = "100", message = MessageUtil.CALORIE_RANGE)
-    @DecimalMax(value = "10000", message = MessageUtil.CALORIE_RANGE)
+    @Range(min = 100, max = 10000, message = MessageUtil.CALORIE_RANGE)
     private int calorie;
 
-    @DecimalMin(value = "100", message = MessageUtil.CARBOHYDRATE_RANGE)
-    @DecimalMax(value = "500", message = MessageUtil.CARBOHYDRATE_RANGE)
+    @Range(min = 100, max = 500, message = MessageUtil.CARBOHYDRATE_RANGE)
     private int carbohydrate;
 
-    @DecimalMin(value = "25", message = MessageUtil.PROTEIN_RANGE)
-    @DecimalMax(value = "500", message = MessageUtil.PROTEIN_RANGE)
+    @Range(min = 25, max = 500, message = MessageUtil.PROTEIN_RANGE)
     private int protein;
 
-    @DecimalMin(value = "25", message = MessageUtil.FAT_RANGE)
-    @DecimalMax(value = "500", message = MessageUtil.FAT_RANGE)
+    @Range(min = 25, max = 500, message = MessageUtil.FAT_RANGE)
     private int fat;
 
     public static UpdateUserNutritionDto of(Long userId, int calorie, int carbohydrate, int protein, int fat) {


### PR DESCRIPTION
## 기존 연관관계
* 음식 -> 즐겨찾는 음식: 일대 일
* 즐겨찾는 음식 -> 음식: 일대 일

## 수정된 연관관계
* 음식 -> 즐겨찾는 음식: 다대 일 (단, 실제로는 일대 일처럼 운용하도록 예외처리)
* 즐겨찾는 음식 -> 음식: 일대 다 (즐겨찾는 음식으로부터 여러 개의 음식이 태어날 수 있다는 점에서 관계의 주인을 즐찾음식으로 설정함)
* FavoriteFoodRepository의 existsByFoodId 삭제 (Food.isFavorite()을 통해 중복 즐찾 여부를 판정하도록 수정)
* 관계의 주인이 즐겨찾기로 명확하게 정해졌으며, food.setFavoriteFood()는 즐겨찾기로부터 음식을 창조하는 경우와 최초로 음식을 즐겨찾기에 등록하는 경우 2가지에서 사용

## 관찰 필요한 동작
- [ ] 특정 음식 객체를 즐겨찾는 음식에 추가 시, 노란 별이 잘 박히고, 즐겨찾기 목록에 잘 추가됐는가?
- [ ] 즐겨찾기에서 특정 음식 클릭하여 새 음식 객체 생성 시, 생성된 객체에 노란 별이 존재하는가?
- [ ] 즐겨찾기에서 특정 음식 삭제 시, 그 음식으로부터 태어난 음식 객체들의 노란 별이 사라지는가?