### PR TITLE
Fix: 즐찾 해제 시 자식 음식객체 연쇄삭제 명시적으로 추가 (#114)

### DIFF
--- a/src/main/java/com/diareat/diareat/food/service/FoodService.java
+++ b/src/main/java/com/diareat/diareat/food/service/FoodService.java
@@ -128,6 +128,8 @@ public class FoodService {
     @Transactional
     public void deleteFavoriteFood(Long favoriteFoodId, Long userId) {
         validateFavoriteFood(favoriteFoodId, userId);
+        FavoriteFood favoriteFood = getFavoriteFoodById(favoriteFoodId);
+        favoriteFood.getFoods().forEach(food -> food.setFavoriteFood(null)); // 즐겨찾기 음식으로부터 태어난 음식들의 즐겨찾기 정보를 null로 초기화
         favoriteFoodRepository.deleteById(favoriteFoodId);
         log.info("즐겨찾기 음식 해제 완료: " + favoriteFoodId);
     }

--- a/src/test/java/com/diareat/diareat/service/FoodServiceTest.java
+++ b/src/test/java/com/diareat/diareat/service/FoodServiceTest.java
@@ -177,10 +177,12 @@ class FoodServiceTest {
         User user = User.createUser("testUser", "testImage","tessPassword", 1, 180, 80, 18, testBaseNutrition);
         Food food = Food.createFood("testFood", user, testBaseNutrition, 2010,1,1);
         FavoriteFood favoriteFood = FavoriteFood.createFavoriteFood("testFood", user, food, testBaseNutrition);
+        food.setFavoriteFood(favoriteFood);
         favoriteFood.setId(1L);
 
         given(favoriteFoodRepository.existsById(favoriteFood.getId())).willReturn(true);
         given(favoriteFoodRepository.existsByIdAndUserId(favoriteFood.getId(), 1L)).willReturn(true);
+        given(favoriteFoodRepository.findById(favoriteFood.getId())).willReturn(Optional.of(favoriteFood));
 
         //when
         foodService.deleteFavoriteFood(favoriteFood.getId(), 1L);


### PR DESCRIPTION
* FavoriteFood가 연관관계의 주인이나, FavoriteFood 소멸 시 이를 바라보던 자식 Food 객체가 null을 바라도록 처리되어야 함
* 허나 의도대로 처리되지 않아 직접 setter로 명시적으로 음식들의 즐찾여부를 해제