### PR TITLE
Feat: 일별 음식에서 해당 날짜 없으면 0 반환 및 한 주 단위로 묶어 데이터 반환 (#120)

### DIFF
--- a/src/main/java/com/diareat/diareat/food/dto/ResponseAnalysisDto.java
+++ b/src/main/java/com/diareat/diareat/food/dto/ResponseAnalysisDto.java
@@ -4,7 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @NoArgsConstructor
@@ -12,16 +14,16 @@ import java.util.List;
 public class ResponseAnalysisDto { // 그래프 + 점수에 사용되는 DTO
 
     private double totalScore;
-    private List<Double> calorieLastSevenDays; // 최근 7일간의 칼로리 (7개 과거부터 나열)
+    private List<Map<LocalDate, Double>> calorieLastSevenDays; // 최근 7일간의 칼로리 (7개 과거부터 나열)
     private List<Double> calorieLastFourWeek; // 최근 4주간의 칼로리 (4개 과거부터 나열)
-    private List<Double> carbohydrateLastSevenDays; // 최근 7일간의 탄수화물
+    private List<Map<LocalDate, Double>> carbohydrateLastSevenDays; // 최근 7일간의 탄수화물
     private List<Double> carbohydrateLastFourWeek; // 최근 4주간의 탄수화물
-    private List<Double> proteinLastSevenDays; // 최근 7일간의 단백질
+    private List<Map<LocalDate, Double>> proteinLastSevenDays; // 최근 7일간의 단백질
     private List<Double> proteinLastFourWeek; // 최근 4주간의 단백질
-    private List<Double> fatLastSevenDays; // 최근 7일간의 지방
+    private List<Map<LocalDate, Double>> fatLastSevenDays; // 최근 7일간의 지방
     private List<Double> fatLastFourWeek; // 최근 4주간의 지방
 
-    public static ResponseAnalysisDto of(double totalScore, List<Double> calorieLastSevenDays, List<Double> calorieLastFourWeek, List<Double> carbohydrateLastSevenDays, List<Double> carbohydrateLastFourWeek, List<Double> proteinLastSevenDays, List<Double> proteinLastFourWeek, List<Double> fatLastSevenDays, List<Double> fatLastFourWeek) {
+    public static ResponseAnalysisDto of(double totalScore, List<Map<LocalDate, Double>> calorieLastSevenDays, List<Double> calorieLastFourWeek,List<Map<LocalDate, Double>> carbohydrateLastSevenDays, List<Double> carbohydrateLastFourWeek,List<Map<LocalDate, Double>> proteinLastSevenDays, List<Double> proteinLastFourWeek, List<Map<LocalDate, Double>> fatLastSevenDays, List<Double> fatLastFourWeek) {
         return new ResponseAnalysisDto(totalScore, calorieLastSevenDays, calorieLastFourWeek, carbohydrateLastSevenDays, carbohydrateLastFourWeek, proteinLastSevenDays, proteinLastFourWeek, fatLastSevenDays, fatLastFourWeek);
     }
 }

--- a/src/main/java/com/diareat/diareat/food/service/FoodService.java
+++ b/src/main/java/com/diareat/diareat/food/service/FoodService.java
@@ -257,33 +257,32 @@ public class FoodService {
 
         double totalWeekScore = calculateUserScoreThisWeek(user, LocalDate.of(year, month, day).with(DayOfWeek.MONDAY), LocalDate.of(year, month, day)).getTotalScore();
 
-        List<Double> calorieLastSevenDays = new ArrayList<>();
+        List<Map<LocalDate,Double>>calorieLastSevenDays = new ArrayList<>();
         List<Double> calorieLastFourWeek = new ArrayList<>();
-        List<Double> carbohydrateLastSevenDays = new ArrayList<>();
+        List<Map<LocalDate,Double>> carbohydrateLastSevenDays = new ArrayList<>();
         List<Double> carbohydrateLastFourWeek = new ArrayList<>();
-        List<Double> proteinLastSevenDays = new ArrayList<>();
+        List<Map<LocalDate,Double>> proteinLastSevenDays = new ArrayList<>();
         List<Double> proteinLastFourWeek = new ArrayList<>();
-        List<Double> fatLastSevenDays = new ArrayList<>();
+        List<Map<LocalDate,Double>> fatLastSevenDays = new ArrayList<>();
         List<Double> fatLastFourWeek = new ArrayList<>();
 
         //최근 7일간의 식습관, 비어있으면 0으로 반환
         for (LocalDate date = currentDate.minusWeeks(1); date.isBefore(currentDate); date = date.plusDays(1)){
-            System.out.println(date);
             if(!nutritionSumOfUserByWeek.containsKey(date)){ //해당 날짜에 먹은 음식이 없는 경우는 0으로 반환
-                calorieLastSevenDays.add(0.0);
-                carbohydrateLastSevenDays.add(0.0);
-                proteinLastSevenDays.add(0.0);
-                fatLastSevenDays.add(0.0);
+                calorieLastSevenDays.add(Map.of(date, 0.0));
+                carbohydrateLastSevenDays.add(Map.of(date, 0.0));
+                proteinLastSevenDays.add(Map.of(date, 0.0));
+                fatLastSevenDays.add(Map.of(date, 0.0));
             }else{
                 int totalKcal = nutritionSumOfUserByWeek.get(date).stream().mapToInt(BaseNutrition::getKcal).sum();
                 int totalCarbohydrate = nutritionSumOfUserByWeek.get(date).stream().mapToInt(BaseNutrition::getCarbohydrate).sum();
                 int totalProtein = nutritionSumOfUserByWeek.get(date).stream().mapToInt(BaseNutrition::getProtein).sum();
                 int totalFat = nutritionSumOfUserByWeek.get(date).stream().mapToInt(BaseNutrition::getFat).sum();
 
-                calorieLastSevenDays.add((double) totalKcal);
-                carbohydrateLastSevenDays.add((double) totalCarbohydrate);
-                proteinLastSevenDays.add((double) totalProtein);
-                fatLastSevenDays.add((double) totalFat);
+                calorieLastSevenDays.add(Map.of(date, (double) totalKcal));
+                carbohydrateLastSevenDays.add(Map.of(date, (double) totalCarbohydrate));
+                proteinLastSevenDays.add(Map.of(date, (double) totalProtein));
+                fatLastSevenDays.add(Map.of(date, (double) totalFat));
             }
         }
 

--- a/src/test/java/com/diareat/diareat/controller/FoodControllerTest.java
+++ b/src/test/java/com/diareat/diareat/controller/FoodControllerTest.java
@@ -12,6 +12,7 @@ import com.diareat.diareat.util.api.ApiResponse;
 import com.diareat.diareat.util.api.ResponseCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.hibernate.validator.internal.util.privilegedactions.LoadClass;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -424,9 +426,9 @@ class FoodControllerTest {
     @WithMockUser("test")
     void testGetAnalysisOfUser() throws Exception {
         //Given
-        ResponseAnalysisDto responseAnalysisDto = ResponseAnalysisDto.of(100, List.of(100.0, 100.0),
-                List.of(100.0, 100.0), List.of(100.0, 100.0), List.of(100.0, 100.0), List.of(100.0, 100.0),
-                List.of(100.0, 100.0), List.of(100.0, 100.0), List.of(100.0, 100.0));
+        ResponseAnalysisDto responseAnalysisDto = ResponseAnalysisDto.of(100, List.of(Map.of(LocalDate.of(2021, 10, 10), 100.0)),
+                List.of(100.0, 100.0), List.of(Map.of(LocalDate.of(2021, 10, 10), 100.0)), List.of(100.0, 100.0), List.of(Map.of(LocalDate.of(2021, 10, 10), 100.0)),
+                List.of(100.0, 100.0), List.of(Map.of(LocalDate.of(2021, 10, 10), 100.0)), List.of(100.0, 100.0));
 
         ApiResponse<ResponseAnalysisDto> expectedResponse = ApiResponse.success(responseAnalysisDto, ResponseCode.FOOD_READ_SUCCESS.getMessage());
         when(foodService.getAnalysisOfUser(any(Long.class), any(int.class), any(int.class), any(int.class))).thenReturn(responseAnalysisDto);
@@ -440,10 +442,10 @@ class FoodControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.header.code").value(expectedResponse.getHeader().getCode()))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.header.message").value(expectedResponse.getHeader().getMessage()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.calorieLastSevenDays[0]").value(expectedResponse.getData().getCalorieLastSevenDays().get(0)))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.carbohydrateLastSevenDays[0]").value(expectedResponse.getData().getCarbohydrateLastSevenDays().get(0)))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.proteinLastSevenDays[0]").value(expectedResponse.getData().getProteinLastSevenDays().get(0)))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.fatLastSevenDays[0]").value(expectedResponse.getData().getFatLastSevenDays().get(0)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.calorieLastSevenDays[0]['2021-10-10']").value(expectedResponse.getData().getCalorieLastSevenDays().get(0).get(LocalDate.of(2021, 10, 10))))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.carbohydrateLastSevenDays[0]['2021-10-10']").value(expectedResponse.getData().getCarbohydrateLastSevenDays().get(0).get(LocalDate.of(2021, 10, 10))))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.proteinLastSevenDays[0]['2021-10-10']").value(expectedResponse.getData().getProteinLastSevenDays().get(0).get(LocalDate.of(2021, 10, 10))))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.fatLastSevenDays[0]['2021-10-10']").value(expectedResponse.getData().getFatLastSevenDays().get(0).get(LocalDate.of(2021, 10, 10))))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.calorieLastFourWeek[0]").value(expectedResponse.getData().getCalorieLastFourWeek().get(0)))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.carbohydrateLastFourWeek[0]").value(expectedResponse.getData().getCarbohydrateLastFourWeek().get(0)))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.proteinLastFourWeek[0]").value(expectedResponse.getData().getProteinLastFourWeek().get(0)))

--- a/src/test/java/com/diareat/diareat/service/FoodServiceTest.java
+++ b/src/test/java/com/diareat/diareat/service/FoodServiceTest.java
@@ -461,8 +461,8 @@ class FoodServiceTest {
         assertEquals(192.95, totalScore);
 
         //갯수 확인
-        assertEquals(3, calorieLastSevenDays.size()); //일주일동안의 음식 -> 3개
-        assertEquals(5, calorieLastFourWeeks.size()); //한달동안의 음식 -> 5개
+        assertEquals(7, calorieLastSevenDays.size()); //일주일동안의 음식 -> 7개 고정
+        assertEquals(4, calorieLastFourWeeks.size()); //한달동안의 음식 -> 5개
 
 
         verify(foodRepository, times(1)).findAllByUserIdAndDateBetweenOrderByAddedTimeAsc(user.getId(), fixedDate.minusWeeks(1), fixedDate);

--- a/src/test/java/com/diareat/diareat/service/FoodServiceTest.java
+++ b/src/test/java/com/diareat/diareat/service/FoodServiceTest.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Sort;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -453,7 +454,7 @@ class FoodServiceTest {
         ResponseAnalysisDto response = foodService.getAnalysisOfUser(user.getId(), fixedDate.getYear(), fixedDate.getMonthValue(), fixedDate.getDayOfMonth());
 
         double totalScore = response.getTotalScore();
-        List<Double> calorieLastSevenDays = response.getCalorieLastSevenDays();
+        List<Map<LocalDate, Double>> calorieLastSevenDays = response.getCalorieLastSevenDays();
         List<Double> calorieLastFourWeeks = response.getCalorieLastFourWeek();
 
 


### PR DESCRIPTION
- 기존 로직은 날짜 없으면 생략하고 다른 날의 음식들을 마저 반환
- 해당 날짜에 음식이 없으면 0을 반환하도록 수정
- 한달간의 음식의 경우, 1주 단위로 묶어 값을 합한 후, 총 4개의 원소를 반환하도록 수정