### PR TITLE
Fix: 기준섭취량 자동계산 옵션 발동되지 않던 버그 수정 (#122)

### DIFF
--- a/src/main/java/com/diareat/diareat/user/domain/User.java
+++ b/src/main/java/com/diareat/diareat/user/domain/User.java
@@ -119,6 +119,8 @@ public class User implements UserDetails {
         this.age = age;
         if(autoUpdate == 1) {
             this.type = UserTypeUtil.decideUserType(this.gender, this.age);
+            List<Integer> standard = UserTypeUtil.getStanardByUserType(this.type);
+            this.baseNutrition = BaseNutrition.createNutrition(standard.get(0), standard.get(2), this.weight, standard.get(1));
         }
     }
 


### PR DESCRIPTION
* 기준섭취량 자동계산 여부에 체크하면 유저의 기준섭취량이 기준에 따라 자동으로 배정(초기화)되어야 함
* 누락된 로직으로 인해 반영되지 않던 버그 수정