### PR TITLE
Fix: JWT 토큰 인증 활성화 및 유효시간 12시간으로 확대 (#131)

### DIFF
--- a/src/main/java/com/diareat/diareat/auth/component/JwtTokenProvider.java
+++ b/src/main/java/com/diareat/diareat/auth/component/JwtTokenProvider.java
@@ -39,7 +39,7 @@ public class JwtTokenProvider {
         return Jwts.builder()
                 .setClaims(claims) // 정보 저장
                 .setIssuedAt(now) // 토큰 발행 시간 정보
-                .setExpiration(new Date(now.getTime() + (360 * 60 * 1000L))) // 토큰 유효시각 설정 (360분)
+                .setExpiration(new Date(now.getTime() + (720 * 60 * 1000L))) // 토큰 유효시각 설정 (12시간)
                 .signWith(SignatureAlgorithm.HS256, secretKey)  // 암호화 알고리즘과, secret 값
                 .compact();
     }

--- a/src/main/java/com/diareat/diareat/config/WebSecurityConfig.java
+++ b/src/main/java/com/diareat/diareat/config/WebSecurityConfig.java
@@ -28,7 +28,7 @@ public class WebSecurityConfig {
                 .and()
                 .authorizeRequests()
                 .antMatchers(AUTH_LIST).permitAll() // swagger 관련 URL은 인증 없이 접근 가능 (테스트용)
-                .antMatchers("/api/**").permitAll() // 회원가입/로그인 관련 URL은 인증 없이 접근 가능
+                .antMatchers("/api/auth/**").permitAll() // 회원가입/로그인 관련 URL은 인증 없이 접근 가능
                 .anyRequest().authenticated() // 나머지 모든 URL은 Jwt 인증 필요
                 .and()
                 .addFilterBefore(new JwtAuthFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
* JWT 토큰 인증 활성화 및 유효시간 12시간으로 확대
* 이제 클라이언트는 /api/auth를 제외한 모든 요청에 accessToken이라는 헤더 변수로 jwtToken을 전송해야 함