### PR TITLE
Fix: 음식명 중복에 대한 예외처리 제거 (#133)

### DIFF
--- a/src/main/java/com/diareat/diareat/food/service/FoodService.java
+++ b/src/main/java/com/diareat/diareat/food/service/FoodService.java
@@ -10,19 +10,14 @@ import com.diareat.diareat.user.domain.User;
 import com.diareat.diareat.user.dto.response.ResponseRankUserDto;
 import com.diareat.diareat.user.repository.FollowRepository;
 import com.diareat.diareat.user.repository.UserRepository;
-import com.diareat.diareat.util.MessageUtil;
 import com.diareat.diareat.util.api.ResponseCode;
 import com.diareat.diareat.util.exception.FavoriteException;
 import com.diareat.diareat.util.exception.FoodException;
 import com.diareat.diareat.util.exception.UserException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cglib.core.Local;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.cache.annotation.Cacheable;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -43,10 +38,6 @@ public class FoodService {
     // @CacheEvict(value = {"ResponseNutritionSumByDateDto"}, key = "#userId+createFoodDto.getDate()", cacheManager = "diareatCacheManager")
     @Transactional
     public Long saveFood(CreateFoodDto createFoodDto) {
-        if (foodRepository.existsByName(createFoodDto.getName())){
-            log.info(createFoodDto.getName() + ": 이미 존재하는 음식 이름입니다.");
-            throw new FoodException(ResponseCode.FOOD_NAME_ALREADY_EXIST);
-        }
         User user = getUserById(createFoodDto.getUserId());
         Food food = Food.createFood(createFoodDto.getName(), user, createFoodDto.getBaseNutrition(), createFoodDto.getYear(), createFoodDto.getMonth(), createFoodDto.getDay());
         log.info("신규 음식 저장: " + food.getName());


### PR DESCRIPTION
* 현재 음식명 중복 등록에 대한 예외처리가 작동 중
* 며칠 전 등록한 음식명이랑 같다는 이유로 거부당하면 사용자 경험에 좋지 않을 것이며, 실제 그 점을 인지하지 못하면 버그로 인식할 가능성
* 예외처리 제거하였고 불필요한 import 정리