### PR TITLE
Fix: Jwt 일부 코드 복구 및 RefreshToken 만료 관련 예외처리 반영 (#152)

### DIFF
--- a/src/main/java/com/diareat/diareat/auth/component/JwtTokenProvider.java
+++ b/src/main/java/com/diareat/diareat/auth/component/JwtTokenProvider.java
@@ -1,7 +1,7 @@
 package com.diareat.diareat.auth.component;
 
 import com.diareat.diareat.util.api.ResponseCode;
-import com.diareat.diareat.util.exception.BaseException;
+import com.diareat.diareat.util.exception.ValidException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
@@ -94,7 +94,7 @@ public class JwtTokenProvider {
     public void validateRefreshToken(Long userPK, String refreshToken) {
         String redisRefreshToken = redisTemplate.opsForValue().get(String.valueOf(userPK));
         if (redisRefreshToken == null || !redisRefreshToken.equals(refreshToken)) {
-            throw new BaseException(ResponseCode.REFRESH_TOKEN_VALIDATION_FAILURE);
+            throw new ValidException(ResponseCode.REFRESH_TOKEN_VALIDATION_FAILURE);
         }
     }
 

--- a/src/main/java/com/diareat/diareat/auth/controller/AuthController.java
+++ b/src/main/java/com/diareat/diareat/auth/controller/AuthController.java
@@ -54,6 +54,13 @@ public class AuthController {
         return ApiResponse.success(responseJwtDto, ResponseCode.USER_CREATE_SUCCESS.getMessage());
     }
 
+    // 토큰 검증 (Jwt 토큰을 서버에 전송하여, 서버가 유효한 토큰인지 확인하고 True 혹은 예외 반환)
+    @Operation(summary = "[토큰 검증] 토큰 검증", description = "클라이언트가 가지고 있던 Jwt 토큰을 서버에 전송하여, 서버가 유효한 토큰인지 확인하고 OK 혹은 예외를 반환합니다.")
+    @GetMapping("/token")
+    public ApiResponse<Boolean> tokenCheck(@RequestHeader String accessToken) {
+        return ApiResponse.success(jwtTokenProvider.validateAccessToken(accessToken), ResponseCode.TOKEN_CHECK_SUCCESS.getMessage());
+    }
+
     @Operation(summary = "[토큰 재발급] 토큰 재발급", description = "클라이언트가 가지고 있던 Refresh 토큰을 서버에 전송하여, 서버가 유효한 토큰인지 확인하고 OK 혹은 예외를 반환합니다.")
     @PostMapping("/reissue")
     public ApiResponse<ResponseJwtDto> reissueToken(@RequestHeader String refreshToken) {

--- a/src/main/java/com/diareat/diareat/util/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/diareat/diareat/util/exception/GlobalExceptionHandler.java
@@ -46,4 +46,11 @@ public class GlobalExceptionHandler {
         });
         return ApiResponse.fail(ResponseCode.BAD_REQUEST, errors);
     }
+
+    @ExceptionHandler(ValidException.class) // jwt 토큰 만료 관련 예외처리
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ApiResponse<Void> handleValidException(ValidException e) {
+        log.info("Invalid Jwt Token: {}", e.getMessage());
+        return ApiResponse.fail(e.getResponseCode(), null);
+    }
 }

--- a/src/main/java/com/diareat/diareat/util/exception/ValidException.java
+++ b/src/main/java/com/diareat/diareat/util/exception/ValidException.java
@@ -1,0 +1,9 @@
+package com.diareat.diareat.util.exception;
+
+import com.diareat.diareat.util.api.ResponseCode;
+
+public class ValidException extends BaseException {
+    public ValidException(ResponseCode responseCode) {
+        super(responseCode);
+    }
+}


### PR DESCRIPTION
* JWT accessToken 관련 유효성 판정 일단 T/F 반환 형식으로 유지 (추후 개편예정)
* RefreshToken의 경우에는 유효성 검증 실패 시 401 관련 예외처리 띄우도록 처리